### PR TITLE
add jade, move groovy to old distros

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,10 +51,11 @@ index_old_doc_paths: false
 
 # ROS distros to look for
 distros:
+  - 'jade'
   - 'indigo'
   - 'hydro'
-  - 'groovy'
 old_distros:
+  - 'groovy'
   - 'fuerte'
   - 'electric'
   - 'diamondback'


### PR DESCRIPTION
I haven't tried the change but thought this should be the right place to add jade.